### PR TITLE
Fix assertion on the Atcoder scraper

### DIFF
--- a/bin/scrape-atcoder
+++ b/bin/scrape-atcoder
@@ -24,7 +24,7 @@ def get_polban_rank(cell):
     """get_polban_rank takes a BeautifulSoup object containing a <td> cell from
     Atcoder leaderboard and returns the user's rank across Polban users."""
     res =  findall(r'\d+', cell.get_text().strip())
-    assert len(res) == 2
+    assert len(res) >= 1
 
     return int(res[0])
 


### PR DESCRIPTION
Fix assertion on the Atcoder scraper so it only validates the first column of the table (showing the rank) to contain one or more integers, instead of requiring two integers to be present.

The assertion failed when it encounters Atcoder members that were inactive for quite some time, causing their Atcoder rank to be shown as "-", but still showing their rank on the university level.

<img width="910" alt="image" src="https://user-images.githubusercontent.com/1644410/107149992-2c091f80-698e-11eb-9831-7de6c4799a40.png">
