### PR TITLE
ci(scrape): add atcoder scraping to GitHub Actions

### DIFF
--- a/.github/workflows/scrape.yaml
+++ b/.github/workflows/scrape.yaml
@@ -22,6 +22,7 @@ jobs:
     - run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - run: bin/scrape-atcoder > data/atcoder.json
     - run: bin/scrape-kattis > data/kattis.json
     - run: |
         git config user.name "Leaderboard scraper"

--- a/data/atcoder.json
+++ b/data/atcoder.json
@@ -1,18 +1,9 @@
 [
     {
-        "birth": 1999,
-        "highest": 6,
-        "match": 2,
-        "polban_rank": 3,
-        "rating": 6,
-        "username": "ivanetra",
-        "win": 0
-    },
-    {
         "birth": 2000,
         "highest": 38,
         "match": 2,
-        "polban_rank": 3,
+        "polban_rank": 1,
         "rating": 38,
         "username": "littletime",
         "win": 0
@@ -20,9 +11,9 @@
     {
         "birth": 1999,
         "highest": 1343,
-        "match": 51,
-        "polban_rank": 2,
-        "rating": 1214,
+        "match": 52,
+        "polban_rank": 1,
+        "rating": 1119,
         "username": "mini4141",
         "win": 0
     },


### PR DESCRIPTION
Include bin/scrape-atcoder in the scheduled scrape job so atcoder.json is kept up to date alongside kattis.json.

Closes #17.