### PR TITLE
Fix codeforces scraper and add it to CI workflow

### DIFF
--- a/.github/workflows/scrape.yaml
+++ b/.github/workflows/scrape.yaml
@@ -23,6 +23,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - run: bin/scrape-atcoder > data/atcoder.json
+    - run: bin/scrape-codeforces > data/codeforces.json
     - run: bin/scrape-kattis > data/kattis.json
     - run: |
         git config user.name "Leaderboard scraper"

--- a/bin/scrape-codeforces
+++ b/bin/scrape-codeforces
@@ -36,7 +36,7 @@ headers = {
     "User-Agent": "cp-leaderboard (https://github.com/jtkencode/cp-leaderboard)"
 }
 
-req = requests.get(URL, headers, timeout=10)
+req = requests.get(URL, headers=headers, timeout=10)
 
 soup = BeautifulSoup(req.content, "html.parser")
 leaderboard_rows = soup.select(".ratingsDatatable tr")

--- a/data/codeforces.json
+++ b/data/codeforces.json
@@ -1,16 +1,23 @@
 [
     {
         "active": false,
+        "participations": 1,
+        "polban_rank": null,
+        "rating": 364,
+        "username": "NewbieStillLearn12"
+    },
+    {
+        "active": false,
         "participations": 17,
         "polban_rank": null,
         "rating": 942,
         "username": "Nexain"
     },
     {
-        "active": true,
-        "participations": 16,
-        "polban_rank": 3,
-        "rating": 811,
+        "active": false,
+        "participations": 30,
+        "polban_rank": null,
+        "rating": 940,
         "username": "ReyRizki47"
     },
     {
@@ -22,16 +29,23 @@
     },
     {
         "active": false,
+        "participations": 7,
+        "polban_rank": null,
+        "rating": 888,
+        "username": "ikhsan3adi"
+    },
+    {
+        "active": false,
         "participations": 4,
         "polban_rank": null,
         "rating": 1138,
         "username": "littletime"
     },
     {
-        "active": true,
-        "participations": 175,
-        "polban_rank": 2,
-        "rating": 1652,
+        "active": false,
+        "participations": 234,
+        "polban_rank": null,
+        "rating": 1512,
         "username": "mini4141"
     },
     {
@@ -42,9 +56,9 @@
         "username": "saifulwebid"
     },
     {
-        "active": true,
+        "active": false,
         "participations": 131,
-        "polban_rank": 1,
+        "polban_rank": null,
         "rating": 1718,
         "username": "x_zadfar"
     }


### PR DESCRIPTION
## Summary

The codeforces scraper was broken due to the `headers` dict being passed as a positional argument to `requests.get()`, which mapped it to the `params` parameter. This appended the User-Agent as a query string, triggering Cloudflare's bot protection (403).

## Changes

- Fix `requests.get()` call to use `headers=headers` keyword arg
- Add `bin/scrape-codeforces` step to the scrape workflow

## Tested

Ran `bin/scrape-codeforces` locally and confirmed it produces valid JSON output with 9 users.

Closes #14.