### PR TITLE
chore(ci): bump checkout and setup-python actions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,8 +5,8 @@ jobs:
     name: Lint Python scripts
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - run: |

--- a/.github/workflows/scrape.yaml
+++ b/.github/workflows/scrape.yaml
@@ -15,8 +15,8 @@ jobs:
     name: Scrape leaderboard data
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.11
     - run: |


### PR DESCRIPTION
Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 16, 2026. Update from checkout@v2 and setup-python@v1 to v6 (Node.js 24 runtime).